### PR TITLE
Add missing Location attributes

### DIFF
--- a/java/elemental2/dom/dom_missing_api.js
+++ b/java/elemental2/dom/dom_missing_api.js
@@ -32,6 +32,88 @@
 function Location() {}
 
 /**
+ * Returns a DOMStringList object listing the origins of the ancestor browsing
+ * contexts, from the parent browsing context to the top-level browsing
+ * context.
+ * @return {DOMStringList}
+ * @see https://html.spec.whatwg.org/multipage/history.html#dom-location-ancestororigins
+ */
+Location.prototype.ancestorOrigins;
+
+/**
+ * Returns the Location object's URL's fragment (includes leading "#" if
+ * non-empty). Can be set, to navigate to the same URL with a changed fragment
+ * (ignores leading "#").
+ * @see https://html.spec.whatwg.org/multipage/history.html#dom-location-hash
+ * @type {string}
+ */
+Location.prototype.hash;
+
+/**
+ * Returns the Location object's URL's host and port (if different from the
+ * default port for the scheme). Can be set, to navigate to the same URL with
+ * a changed host and port.
+ * @see https://html.spec.whatwg.org/multipage/history.html#dom-location-host
+ * @type {string}
+ */
+Location.prototype.host;
+
+/**
+ * Returns the Location object's URL's host. Can be set, to navigate to the
+ * same URL with a changed host.
+ * @see https://html.spec.whatwg.org/multipage/history.html#dom-location-hostname
+ * @type {string}
+ */
+Location.prototype.hostname;
+
+/**
+ * Returns the Location object's URL. Can be set, to navigate to the given URL.
+ * @see https://html.spec.whatwg.org/multipage/history.html#dom-location-href
+ * @type {string}
+ */
+Location.prototype.href;
+
+/**
+ * Returns the Location object's URL's origin.
+ * @see https://html.spec.whatwg.org/multipage/history.html#dom-location-origin
+ * @const {string}
+ */
+Location.prototype.origin;
+
+/**
+ * Returns the Location object's URL's path. Can be set, to navigate to the
+ * same URL with a changed path.
+ * @see https://html.spec.whatwg.org/multipage/history.html#dom-location-pathname
+ * @type {string}
+ */
+Location.prototype.pathname;
+
+/**
+ * Returns the Location object's URL's port. Can be set, to navigate to the
+ * same URL with a changed port.
+ * @see https://html.spec.whatwg.org/multipage/history.html#dom-location-port
+ * @type {number}
+ */
+Location.prototype.port;
+
+/**
+ * Returns the Location object's URL's scheme. Can be set, to navigate to the
+ * same URL with a changed scheme.
+ * @see https://html.spec.whatwg.org/multipage/history.html#dom-location-protocol
+ * @type {string}
+ */
+Location.prototype.protocol;
+
+/**
+ * Returns the Location object's URL's query (includes leading "?" if
+ * non-empty). Can be set, to navigate to the same URL with a changed query
+ * (ignores leading "?").
+ * @see https://html.spec.whatwg.org/multipage/history.html#dom-location-search
+ * @type {string}
+ */
+Location.prototype.search;
+
+/**
  * Navigates to the given page.
  * @param {string} url
  * @return {undefined}


### PR DESCRIPTION
Fix issue https://github.com/google/elemental2/issues/2 adding missing Location attributes. In HTML5 this attributes seems to be in the [UrlUtils interface](https://www.w3.org/TR/html5/browsers.html#dom-location-assign), but in pre-HTML5 are all of them in [Location](https://html.spec.whatwg.org/multipage/history.html#location).

I have spent some time to learn bazel and closure externs. But... I still have some doubts, this is the generated java file.
```java
package elemental2.dom;

import java.lang.Object;
import java.lang.String;
import jsinterop.annotations.JsPackage;
import jsinterop.annotations.JsProperty;
import jsinterop.annotations.JsType;

@JsType(isNative = true, namespace = JsPackage.GLOBAL)
public interface Location {
  DOMStringList ancestorOrigins();

  void assign(String url);

  @JsProperty
  String getHash();

  @JsProperty
  String getHost();

  @JsProperty
  String getHostname();

  @JsProperty
  String getHref();

  @JsProperty
  String getOrigin();

  @JsProperty
  String getPathname();

  @JsProperty
  Object getPort();

  @JsProperty
  String getProtocol();

  @JsProperty
  String getSearch();

  void reload();

  void reload(boolean forceReload);

  void replace(String url);

  @JsProperty
  void setHash(String hash);

  @JsProperty
  void setHost(String host);

  @JsProperty
  void setHostname(String hostname);

  @JsProperty
  void setHref(String href);

  @JsProperty
  void setOrigin(String origin);

  @JsProperty
  void setPathname(String pathname);

  @JsProperty
  void setPort(Object port);

  @JsProperty
  void setProtocol(String protocol);

  @JsProperty
  void setSearch(String search);
}
```

Why are the fields getters? is it possible to change it? From jsinterop-generator seems to be that this is an extension of the "other" closure externs, and it doesn't allow to create a field, but I'm not sure. Also, it is possible to indicate read-only?
