### PR TITLE
Fix path to w3c_eventsource so build can pass

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -160,7 +160,7 @@ alias(
 
 alias(
    name = "w3c_eventsource.js",
-   actual = "@com_google_closure_compiler//:contrib/externs/w3c_eventsource.js",
+   actual = "@com_google_closure_compiler//:externs/browser/w3c_eventsource.js",
 )
 
 alias(


### PR DESCRIPTION
The referenced file does not exist in that directory.