### PR TITLE
Fix Location.prototype.port type (should be string, not number)

### DIFF
--- a/java/elemental2/dom/dom_missing_api.js
+++ b/java/elemental2/dom/dom_missing_api.js
@@ -92,7 +92,7 @@ Location.prototype.pathname;
  * Returns the Location object's URL's port. Can be set, to navigate to the
  * same URL with a changed port.
  * @see https://html.spec.whatwg.org/multipage/history.html#dom-location-port
- * @type {number}
+ * @type {string}
  */
 Location.prototype.port;
 


### PR DESCRIPTION
Fixes #24 