### PR TITLE
Promise.all and race require being passed arrays, not varargs

### DIFF
--- a/java/elemental2/promise/Promise.java
+++ b/java/elemental2/promise/Promise.java
@@ -98,9 +98,19 @@ public class Promise<T> implements IThenable<T> {
     }
   }
 
-  public static native <V> Promise<V[]> all(IThenable<? extends V>... promises);
+  @JsOverlay
+  public static <V> Promise<V[]> all(IThenable<? extends V>... promises) {
+    return allInternal(promises);
+  }
+  @JsMethod(name = "all")
+  private static native <V> Promise<V[]> allInternal(IThenable<? extends V>[] promises);
 
-  public static native <V> Promise<V> race(IThenable<? extends V>... promises);
+  @JsOverlay
+  public static <V> Promise<V> race(IThenable<? extends V>... promises) {
+    return raceInternal(promises);
+  }
+  @JsMethod(name = "race")
+  private static native <V> Promise<V> raceInternal(IThenable<? extends V>[] promises);
 
   public static native Promise<Object> reject(Object error);
 


### PR DESCRIPTION
This is technically an API-breaking change, but I think we're still at RC1, so that is probably okay? Alternate proposal discussed at the end.

The existing code generates invalid JS, but no exception is actually thrown, instead any chained promise just fails right away.

Java:

    Promise.all(somePromise, otherPromise).then(...)

Expected generated JS:

    Promise.all([somePromise, otherPromise]).then(...)

Actual generated JS:

    Promise.all(somePromise, otherPromise).then(...)

Promise.all and Promise.race are specified as taking an iterable of promises (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all, https://www.ecma-international.org/ecma-262/6.0/#sec-promise.all), but the elemental2 versions take varargs instead, and there is no way to specify that this should be "boxed" into a real array before being passed to the underlying JS.

Using this patch, the above would be written

    Promise.all(new Promise[]{ somePromise, otherPromise }).then(...)

Another option would be to take `JsArray<Promise>` instead of the Java array.
---

Alternatively, we could add a private "internal" impl like we used to do in JSOs, and wrap up the incoming varargs as an array before passing them in. Doing so would make this change backward compatible. However, if the goal is to have the Java simply look like strongly typed JS, then the proposed patch may be better.

    @JsOverlay
    public static <V> Promise<V[]> all(IThenable<? extends V>... promises) {
      return allNative(promises);
    }
    @JsMethod(name="all")
    private static native <V> Promise<V[]> allNative(IThenable<? extends V>[] promises);

I have not tested this approach.