### PR TITLE
change the NodeList.ForEachCallbackFn.onInvoke second parameter type from double to int

### DIFF
--- a/java/elemental2/dom/BUILD
+++ b/java/elemental2/dom/BUILD
@@ -129,6 +129,7 @@ filegroup(
 jsinterop_generator(
     name = "dom",
     srcs = [":externs"],
+    name_mapping_files = ["name_mappings.txt"],
     integer_entities_files = ["integer_entities.txt"],
     deps = [
         "//java/elemental2/core",

--- a/java/elemental2/dom/integer_entities.txt
+++ b/java/elemental2/dom/integer_entities.txt
@@ -305,3 +305,4 @@ elemental2.dom.DomGlobal.mozCancelAnimationFrame.handle
 elemental2.dom.DomGlobal.msCancelAnimationFrame.handle
 elemental2.dom.DomGlobal.oCancelAnimationFrame.handle
 elemental2.dom.DomGlobal.webkitCancelAnimationFrame.handle
+elemental2.dom.NodeList.ForEachCallbackFn.onInvoke.p1

--- a/java/elemental2/dom/integer_entities.txt
+++ b/java/elemental2/dom/integer_entities.txt
@@ -305,4 +305,4 @@ elemental2.dom.DomGlobal.mozCancelAnimationFrame.handle
 elemental2.dom.DomGlobal.msCancelAnimationFrame.handle
 elemental2.dom.DomGlobal.oCancelAnimationFrame.handle
 elemental2.dom.DomGlobal.webkitCancelAnimationFrame.handle
-elemental2.dom.NodeList.ForEachCallbackFn.onInvoke.p1
+elemental2.dom.NodeList.ForEachCallbackFn.onInvoke.currentIndex

--- a/java/elemental2/dom/name_mappings.txt
+++ b/java/elemental2/dom/name_mappings.txt
@@ -1,0 +1,3 @@
+elemental2.dom.NodeList.ForEachCallbackFn.onInvoke.p0=currentValue
+elemental2.dom.NodeList.ForEachCallbackFn.onInvoke.p1=currentIndex
+elemental2.dom.NodeList.ForEachCallbackFn.onInvoke.p2=listObj


### PR DESCRIPTION
The second parameter of the NodeList.ForEachCallbackFn.onInvoke method represent an index and is supposed to be int according to :
https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach