### PR TITLE
Promise.reject is a promise of any arbitrary type, not just Object

### DIFF
--- a/java/elemental2/promise/Promise.java
+++ b/java/elemental2/promise/Promise.java
@@ -119,7 +119,7 @@ public class Promise<T> implements IThenable<T> {
   @JsMethod(name = "race")
   private static native <V> Promise<V> raceInternal(IThenable<? extends V>[] promises);
 
-  public static native Promise<Object> reject(Object error);
+  public static native <V> Promise<V> reject(Object error);
 
   @JsOverlay
   public static final <V> Promise<V> resolve(IThenable<V> value) {


### PR DESCRIPTION
Without this, when writing some promise wiring (other than outright throwing, somewhat problematic in and of itself), you end up needing an unchecked cast to assign the promise.

```
public Promise<MyData> load() {
  return somePromise.then(value -> {
    if (value.isGood()) {
      return Promise.resolve(value.data());
    } else {
      //noinspection unchecked
      return (Promise) Promise.reject("failed");
    }
  });
}
```