### PR TITLE
Add requestIdleCallback API to elemental-dom artifact

### DIFF
--- a/java/elemental2/dom/BUILD
+++ b/java/elemental2/dom/BUILD
@@ -122,6 +122,7 @@ filegroup(
         "//third_party:w3c_elementtraversal.js",
         "//third_party:w3c_selectors.js",
         "//third_party:w3c_geolocation.js",
+        "//third_party:w3c_requestidlecallback.js",
     ],
 )
 

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -152,6 +152,12 @@ alias(
     name = "w3c_serviceworker.js",
     actual = "@com_google_closure_compiler//:externs/browser/w3c_serviceworker.js",
 )
+
+alias(
+   name = "w3c_requestidlecallback.js",
+   actual = "@com_google_closure_compiler//:externs/browser/w3c_requestidlecallback.js",
+)
+
 alias(
    name = "w3c_navigation_timing.js",
    actual = "@com_google_closure_compiler//:externs/browser/w3c_navigation_timing.js",


### PR DESCRIPTION
The requestIdleCallback API has been around for a reasonable length of time and implemented in Chrome and Firefox for a while (See https://caniuse.com/#search=requestIdleCallback). Closure already has externs for it at `externs/browser/w3c_requestidlecallback.js` and this has not seen any structural changes since 2015.

Would it be possible to include this API in `elemental-dom` artifact.