### PR TITLE
Generate an artifact based on WebAssembly externs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Elemental2 is split up in several jars files. Refer to the following targets in 
  promise | `@com_google_elemental2//java/elemental2/promise`
  indexeddb | `@com_google_elemental2//java/elemental2/indexeddb`
  svg | `@com_google_elemental2//java/elemental2/svg`
+ webassembly | `@com_google_elemental2//java/elemental2/webassembly`
  webgl | `@com_google_elemental2//java/elemental2/webgl`
  media | `@com_google_elemental2//java/elemental2/media`
  webstorage | `@com_google_elemental2//java/elemental2/webstorage`
@@ -60,6 +61,7 @@ If your project use [Maven](https://maven.apache.org), add maven dependencies in
  promise | `elemental2-promise`
  indexeddb | `elemental2-indexeddb`
  svg | `elemental2-svg`
+ webassembly | `elemental2-webassembly`
  webgl | `elemental2-webgl`
  media | `elemental2-media`
  webstorage | `elemental2-webstorage`
@@ -75,6 +77,7 @@ You can also download manually the jars files.
  promise | [elemental2-promise.jar](https://oss.sonatype.org/content/repositories/releases/com/google/elemental2/elemental2-promise/1.0.0-RC1/elemental2-promise-1.0.0-RC1.jar)
  indexeddb | [elemental2-indexeddb.jar](https://oss.sonatype.org/content/repositories/releases/com/google/elemental2/elemental2-indexeddb/1.0.0-RC1/elemental2-indexeddb-1.0.0-RC1.jar)
  svg | [elemental2-svg.jar](https://oss.sonatype.org/content/repositories/releases/com/google/elemental2/elemental2-svg/1.0.0-RC1/elemental2-svg-1.0.0-RC1.jar)
+ webassembly | [elemental2-webassembly.jar](https://oss.sonatype.org/content/repositories/releases/com/google/elemental2/elemental2-webassembly/1.0.0-RC1/elemental2-webassembly-1.0.0-RC1.jar)
  webgl | [elemental2-webgl.jar](https://oss.sonatype.org/content/repositories/releases/com/google/elemental2/elemental2-webgl/1.0.0-RC1/elemental2-webgl-1.0.0-RC1.jar)
  media | [elemental2-media.jar](https://oss.sonatype.org/content/repositories/releases/com/google/elemental2/elemental2-media/1.0.0-RC1/elemental2-media-1.0.0-RC1.jar)
  webstorage | [elemental2-webstorage.jar](https://oss.sonatype.org/content/repositories/releases/com/google/elemental2/elemental2-webstorage/1.0.0-RC1/elemental2-webstorage-1.0.0-RC1.jar)
@@ -90,6 +93,7 @@ If you use Elemental2 with [GWT](http://www.gwtproject.org/), you need to inheri
  promise | `elemental2.promise.Promise`
  indexeddb | `elemental2.indexeddb.IndexedDb`
  svg | `elemental2.svg.Svg`
+ webassembly | `elemental2.webassembly.WebAssembly`
  webgl | `elemental2.webgl.WebGl`
  media | `elemental2.media.Media`
  webstorage | `elemental2.webstorage.WebStorage`

--- a/java/elemental2/webassembly/BUILD
+++ b/java/elemental2/webassembly/BUILD
@@ -1,0 +1,27 @@
+# This package contains the build rule to build elemental2-webassembly.
+
+package(default_visibility = [
+    "//:__subpackages__",
+])
+
+# Apache2
+licenses(["notice"])
+
+load("@com_google_jsinterop_generator//:jsinterop_generator.bzl", "jsinterop_generator")
+
+filegroup(
+    name = "externs",
+    srcs = ["//third_party:webassembly.js"],
+)
+
+jsinterop_generator(
+    name = "webassembly",
+    srcs = [":externs"],
+    extension_type_prefix = "WebAssembly",
+    name_mapping_files = ["name_mappings.txt"],
+    integer_entities_files = ["integer_entities.txt"],
+    deps = [
+        "//java/elemental2/core",
+        "//java/elemental2/promise",
+    ],
+)

--- a/java/elemental2/webassembly/integer_entities.txt
+++ b/java/elemental2/webassembly/integer_entities.txt
@@ -1,0 +1,15 @@
+elemental2.webassembly.MemoryDescriptor.getInitial
+elemental2.webassembly.MemoryDescriptor.getMaximum
+elemental2.webassembly.MemoryDescriptor.setInitial.initial
+elemental2.webassembly.MemoryDescriptor.setMaximum.maximum
+elemental2.webassembly.TableDescriptor.getInitial
+elemental2.webassembly.TableDescriptor.getMaximum
+elemental2.webassembly.TableDescriptor.setInitial.initial
+elemental2.webassembly.TableDescriptor.setMaximum.maximum
+elemental2.webassembly.webassembly.Memory.grow
+elemental2.webassembly.webassembly.Memory.grow.delta
+elemental2.webassembly.webassembly.Table.get.index
+elemental2.webassembly.webassembly.Table.grow
+elemental2.webassembly.webassembly.Table.grow.delta
+elemental2.webassembly.webassembly.Table.length
+elemental2.webassembly.webassembly.Table.set.index

--- a/java/elemental2/webassembly/name_mappings.txt
+++ b/java/elemental2/webassembly/name_mappings.txt
@@ -1,0 +1,2 @@
+elemental2.webassembly.webassembly.Table.GetFn.onInvoke.p0=parameters
+elemental2.webassembly.webassembly.Table.SetValueFn.onInvoke.p0=parameters

--- a/maven/pom-webassembly.xml
+++ b/maven/pom-webassembly.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>__GROUP_ID__</groupId>
+  <artifactId>__ARTIFICAT_ID__</artifactId>
+  <version>__VERSION__</version>
+  <packaging>jar</packaging>
+
+  <name>Elemental2 WebAssembly</name>
+  <description>Thin Java abstractions for the native Web Assembly APIs.</description>
+  <url>https://www.gwtproject.org</url>
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:git@github.com:google/elemental2.git</connection>
+    <developerConnection>scm:git:git@github.com:google/elemental2.git</developerConnection>
+    <url>git@github.com:google/elemental2.git</url>
+  </scm>
+
+  <issueManagement>
+    <url>https://github.com/google/elemental2/issues</url>
+    <system>GitHub Issues</system>
+  </issueManagement>
+
+  <developers>
+    <developer>
+      <name>j2cl team</name>
+      <organization>Google</organization>
+      <organizationUrl>http://www.google.com</organizationUrl>
+    </developer>
+  </developers>
+
+  <dependencies>
+    <dependency>
+      <groupId>__GROUP_ID__</groupId>
+      <artifactId>elemental2-core</artifactId>
+      <version>__VERSION__</version>
+    </dependency>
+    <dependency>
+      <groupId>__GROUP_ID__</groupId>
+      <artifactId>elemental2-promise</artifactId>
+      <version>__VERSION__</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/release_elemental.sh
+++ b/release_elemental.sh
@@ -18,7 +18,7 @@ read -s gpg_passphrase
 
 cd ${bazel_root}
 
-elemental_artifacts="core dom indexeddb media promise svg webgl webstorage"
+elemental_artifacts="core dom indexeddb media promise svg webgl webstorage webassembly"
 
 for artifact in ${elemental_artifacts}; do
   artifact_path=${bazel_root}/bazel-bin/java/elemental2/${artifact}

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -232,6 +232,11 @@ alias(
 )
 
 alias(
+   name = "webassembly.js",
+   actual = "@com_google_closure_compiler//:contrib/externs/webassembly.js",
+)
+
+alias(
     name = "streamsapi.js",
     actual = "@com_google_closure_compiler//:externs/browser/streamsapi.js",
 )


### PR DESCRIPTION
Create a webassembly artifact based on externs in closure. Wasm/WebAssembly is now present in all evergreen browsers  as evidenced by https://caniuse.com/#feat=wasm and it would useful to have an elemental2 api to interact with it.

A previous PR at https://github.com/google/elemental2/pull/49 attempted the same and this is a slightly improved version. 