### PR TITLE
Patch the closure type for AbortController.abort() to gen correct code

### DIFF
--- a/java/elemental2/dom/BUILD
+++ b/java/elemental2/dom/BUILD
@@ -84,6 +84,14 @@ patch_extern_file(
     patch_file = "w3c_serviceworker.js.diff",
 )
 
+# Patch for w3c_abort.js that causes generator to incorrectly generate type of abort function.
+# The extern file can probably be cleaned up directly
+patch_extern_file(
+    name = "w3c_abort_patched",
+    src = "//third_party:w3c_abort.js",
+    patch_file = "w3c_abort.js.diff",
+)
+
 filegroup(
     name = "externs",
     srcs = [
@@ -112,7 +120,7 @@ filegroup(
         # TODO(dramaix): remove old webkit api and rename file to w3c_notifications.js
         "//third_party:webkit_notifications.js",
         "//third_party:streamsapi.js",
-        "//third_party:w3c_abort.js",
+        ":w3c_abort_patched",
         "//third_party:fetchapi.js",
         ":w3c_serviceworker_patched",
         ":w3c_navigation_timing_patched",

--- a/java/elemental2/dom/w3c_abort.js.diff
+++ b/java/elemental2/dom/w3c_abort.js.diff
@@ -1,0 +1,9 @@
+49,50c49,53
+< /** @const {function()} */
+< AbortController.prototype.abort;
+---
+> /**
+>  * @const
+>  * @return {void}
+>  */
+> AbortController.prototype.abort = function() {};


### PR DESCRIPTION
Prior to this patch the AbortController generated a class

```java
@JsType(isNative = true, namespace = JsPackage.GLOBAL)
public class AbortController {
  @JsFunction
  public interface AbortFn {
    Object onInvoke();
  }

  public AbortController.AbortFn abort;
  public AbortSignal signal;
}
```

However when this was used in a GWT 2.8.2 it would produce incorrect code. For example
`_abortController.abort.onInvoke()` would be compiled to `this._abortController.abort.call(null)`
which would result in an error from the browser.

The patched closure extern will generate working code that looks like:

```java
@JsType( isNative = true, namespace = JsPackage.GLOBAL )
public class AbortController
{
  public AbortSignal signal;

  public native void abort();
}
```