### PR TITLE
Patch the return value of the WebSocket.onmessage function

### DIFF
--- a/java/elemental2/dom/BUILD
+++ b/java/elemental2/dom/BUILD
@@ -42,6 +42,7 @@ patch_extern_file(
 #  and should not be part from Elemental. There is a dependency to this type in html5.js
 #  where DataTransfer extends ClipboardData. We've made an attempt to break
 #  this dependency (http://cl/124542026) but that breaks apps (http://b/29263729).
+#  This file also patches return type of WebSocket.onmessage function. This could be migrated back to externs file.
 patch_extern_file(
     name = "html5_patched",
     src = "//third_party:html5.js",

--- a/java/elemental2/dom/html5.js.diff
+++ b/java/elemental2/dom/html5.js.diff
@@ -19,3 +19,7 @@
 <  * @nosideeffects
 <  */
 < DataTransferItem.prototype.webkitGetAsEntry = function() { return null; };
+2984c2984
+<  * @type {?function(!MessageEvent<?>)}
+---
+>  * @type {?(function(!MessageEvent<?>): void)}


### PR DESCRIPTION
It should be a void/undefined return type and now it is