### PR TITLE
Add additional sections to the POMs

### DIFF
--- a/maven/pom-core.xml
+++ b/maven/pom-core.xml
@@ -12,6 +12,33 @@
   <description>Thin Java abstractions for the standard built-in objects for Javascript.</description>
   <url>https://www.gwtproject.org</url>
 
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:https://github.com/google/elemental2.git</connection>
+    <developerConnection>scm:git:git@github.com:google/elemental2.git</developerConnection>
+    <url>https://github.com/google/elemental2</url>
+  </scm>
+
+  <issueManagement>
+    <url>https://github.com/google/elemental2/issues</url>
+    <system>GitHub Issues</system>
+  </issueManagement>
+
+  <developers>
+    <developer>
+      <name>j2cl team</name>
+      <organization>Google</organization>
+      <organizationUrl>http://www.google.com</organizationUrl>
+    </developer>
+  </developers>
+
   <dependencies>
     <dependency>
       <groupId>com.google.jsinterop</groupId>

--- a/maven/pom-dom.xml
+++ b/maven/pom-dom.xml
@@ -12,6 +12,33 @@
   <description>Thin Java abstractions for the native Browser APIs.</description>
   <url>https://www.gwtproject.org</url>
 
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:https://github.com/google/elemental2.git</connection>
+    <developerConnection>scm:git:git@github.com:google/elemental2.git</developerConnection>
+    <url>https://github.com/google/elemental2</url>
+  </scm>
+
+  <issueManagement>
+    <url>https://github.com/google/elemental2/issues</url>
+    <system>GitHub Issues</system>
+  </issueManagement>
+
+  <developers>
+    <developer>
+      <name>j2cl team</name>
+      <organization>Google</organization>
+      <organizationUrl>http://www.google.com</organizationUrl>
+    </developer>
+  </developers>
+
   <dependencies>
     <dependency>
       <groupId>com.google.jsinterop</groupId>

--- a/maven/pom-indexeddb.xml
+++ b/maven/pom-indexeddb.xml
@@ -12,6 +12,33 @@
   <description>Thin Java abstractions for the IndexedDB APIs</description>
   <url>https://www.gwtproject.org</url>
 
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:https://github.com/google/elemental2.git</connection>
+    <developerConnection>scm:git:git@github.com:google/elemental2.git</developerConnection>
+    <url>https://github.com/google/elemental2</url>
+  </scm>
+
+  <issueManagement>
+    <url>https://github.com/google/elemental2/issues</url>
+    <system>GitHub Issues</system>
+  </issueManagement>
+
+  <developers>
+    <developer>
+      <name>j2cl team</name>
+      <organization>Google</organization>
+      <organizationUrl>http://www.google.com</organizationUrl>
+    </developer>
+  </developers>
+
   <dependencies>
     <dependency>
       <groupId>com.google.jsinterop</groupId>

--- a/maven/pom-media.xml
+++ b/maven/pom-media.xml
@@ -12,6 +12,33 @@
   <description>Thin Java abstractions for the native media APIs provided by the browser.</description>
   <url>https://www.gwtproject.org</url>
 
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:https://github.com/google/elemental2.git</connection>
+    <developerConnection>scm:git:git@github.com:google/elemental2.git</developerConnection>
+    <url>https://github.com/google/elemental2</url>
+  </scm>
+
+  <issueManagement>
+    <url>https://github.com/google/elemental2/issues</url>
+    <system>GitHub Issues</system>
+  </issueManagement>
+
+  <developers>
+    <developer>
+      <name>j2cl team</name>
+      <organization>Google</organization>
+      <organizationUrl>http://www.google.com</organizationUrl>
+    </developer>
+  </developers>
+
   <dependencies>
     <dependency>
       <groupId>com.google.jsinterop</groupId>

--- a/maven/pom-promise.xml
+++ b/maven/pom-promise.xml
@@ -12,6 +12,33 @@
   <description>Thin Java abstractions for the native promise APIs provided by JavaScript engine.</description>
   <url>https://www.gwtproject.org</url>
 
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:https://github.com/google/elemental2.git</connection>
+    <developerConnection>scm:git:git@github.com:google/elemental2.git</developerConnection>
+    <url>https://github.com/google/elemental2</url>
+  </scm>
+
+  <issueManagement>
+    <url>https://github.com/google/elemental2/issues</url>
+    <system>GitHub Issues</system>
+  </issueManagement>
+
+  <developers>
+    <developer>
+      <name>j2cl team</name>
+      <organization>Google</organization>
+      <organizationUrl>http://www.google.com</organizationUrl>
+    </developer>
+  </developers>
+
   <dependencies>
     <dependency>
       <groupId>com.google.jsinterop</groupId>

--- a/maven/pom-svg.xml
+++ b/maven/pom-svg.xml
@@ -12,6 +12,33 @@
   <description>Thin Java abstractions for the native SVG APIs.</description>
   <url>https://www.gwtproject.org</url>
 
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:https://github.com/google/elemental2.git</connection>
+    <developerConnection>scm:git:git@github.com:google/elemental2.git</developerConnection>
+    <url>https://github.com/google/elemental2</url>
+  </scm>
+
+  <issueManagement>
+    <url>https://github.com/google/elemental2/issues</url>
+    <system>GitHub Issues</system>
+  </issueManagement>
+
+  <developers>
+    <developer>
+      <name>j2cl team</name>
+      <organization>Google</organization>
+      <organizationUrl>http://www.google.com</organizationUrl>
+    </developer>
+  </developers>
+
   <dependencies>
     <dependency>
       <groupId>com.google.jsinterop</groupId>

--- a/maven/pom-webgl.xml
+++ b/maven/pom-webgl.xml
@@ -12,6 +12,33 @@
   <description>Thin Java abstractions for the native Web Graphics Library APIs.</description>
   <url>https://www.gwtproject.org</url>
 
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:https://github.com/google/elemental2.git</connection>
+    <developerConnection>scm:git:git@github.com:google/elemental2.git</developerConnection>
+    <url>https://github.com/google/elemental2</url>
+  </scm>
+
+  <issueManagement>
+    <url>https://github.com/google/elemental2/issues</url>
+    <system>GitHub Issues</system>
+  </issueManagement>
+
+  <developers>
+    <developer>
+      <name>j2cl team</name>
+      <organization>Google</organization>
+      <organizationUrl>http://www.google.com</organizationUrl>
+    </developer>
+  </developers>
+
   <dependencies>
     <dependency>
       <groupId>com.google.jsinterop</groupId>

--- a/maven/pom-webstorage.xml
+++ b/maven/pom-webstorage.xml
@@ -12,6 +12,33 @@
   <description>Thin Java abstractions for the native Web Storage APIs.</description>
   <url>https://www.gwtproject.org</url>
 
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:https://github.com/google/elemental2.git</connection>
+    <developerConnection>scm:git:git@github.com:google/elemental2.git</developerConnection>
+    <url>https://github.com/google/elemental2</url>
+  </scm>
+
+  <issueManagement>
+    <url>https://github.com/google/elemental2/issues</url>
+    <system>GitHub Issues</system>
+  </issueManagement>
+
+  <developers>
+    <developer>
+      <name>j2cl team</name>
+      <organization>Google</organization>
+      <organizationUrl>http://www.google.com</organizationUrl>
+    </developer>
+  </developers>
+
   <dependencies>
     <dependency>
       <groupId>com.google.jsinterop</groupId>


### PR DESCRIPTION
These sections are NOT needed for tools that use the POMs but are
required if you want to publish artifacts to Maven Central based
on these POMs and the artifacts do not come from a blessed
repository (i.e. you are deploying via https://oss.sonatype.org).
