### PR TITLE
Add definition of ClientRect back to the dom library

### DIFF
--- a/java/elemental2/dom/BUILD
+++ b/java/elemental2/dom/BUILD
@@ -107,6 +107,7 @@ filegroup(
         "//third_party:w3c_range.js",
         "//third_party:w3c_css.js",
         "//third_party:w3c_css3d.js",
+        "//third_party:w3c_geometry1.js",
         "//third_party:w3c_xml.js",
         "//third_party:flash.js",
         "//third_party:w3c_anim_timing.js",

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -124,6 +124,11 @@ alias(
 )
 
 alias(
+    name = "w3c_geometry1.js",
+    actual = "@com_google_closure_compiler//:externs/browser/w3c_geometry1.js",
+)
+
+alias(
     name = "w3c_xml.js",
     actual = "@com_google_closure_compiler//:externs/browser/w3c_xml.js",
 )


### PR DESCRIPTION
In the commit google/closure-compiler@3a15b2a77a01e84aee8204776506c52c78434fd6
the ClientRect was moved to a separate extern. This adds the new extern into
the DOM build again.