### PR TITLE
Explicitly name some parameters in callback methods

### DIFF
--- a/java/elemental2/dom/name_mappings.txt
+++ b/java/elemental2/dom/name_mappings.txt
@@ -7,3 +7,6 @@ elemental2.dom.WorkerGlobalScope.OnerrorFn.onInvoke.p1=source
 elemental2.dom.WorkerGlobalScope.OnerrorFn.onInvoke.p2=lineno
 elemental2.dom.WorkerGlobalScope.OnerrorFn.onInvoke.p3=colno
 elemental2.dom.WorkerGlobalScope.OnerrorFn.onInvoke.p4=error
+elemental2.dom.WebSocket.OnopenFn.onInvoke.p0=event
+elemental2.dom.WebSocket.OnmessageFn.onInvoke.p0=event
+elemental2.dom.WebSocket.OncloseFn.onInvoke.p0=event


### PR DESCRIPTION
This improves readability of the callbacks and also significantly
improves the naming of the synthesized UnionType classes that the
parameters represent