### PR TITLE
Specify that the MediaError static values are integers

### DIFF
--- a/java/elemental2/dom/integer_entities.txt
+++ b/java/elemental2/dom/integer_entities.txt
@@ -188,6 +188,10 @@ elemental2.dom.LongRange.getMax
 elemental2.dom.LongRange.setMax.max
 elemental2.dom.LongRange.getMin
 elemental2.dom.LongRange.setMin.min
+elemental2.dom.MediaError.MEDIA_ERR_ABORTED
+elemental2.dom.MediaError.MEDIA_ERR_DECODE
+elemental2.dom.MediaError.MEDIA_ERR_NETWORK
+elemental2.dom.MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED
 elemental2.dom.MediaError.code
 elemental2.dom.MediaList.length
 elemental2.dom.MediaList.item.index


### PR DESCRIPTION
This aligns wtih the spec. See https://developer.mozilla.org/en-US/docs/Web/API/MediaError

This changed addresses some of the issues highlighted in #71 