### PR TITLE
Add an explicit dependency from the core to promise

### DIFF
--- a/maven/pom-core.xml
+++ b/maven/pom-core.xml
@@ -50,5 +50,10 @@
       <artifactId>base</artifactId>
       <version>1.0.0-RC1</version>
     </dependency>
+    <dependency>
+      <groupId>__GROUP_ID__</groupId>
+      <artifactId>elemental2-promise</artifactId>
+      <version>__VERSION__</version>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
The dependency exists in code as classes in core reference the Promise type. The dependency exists in the GWT descriptor where the `Core.gwt.xml` inherits `elemental2.promise.Promise` modeul. This change just makes the dependency explicit in the Maven POM.