### PR TITLE
Remove local patch against w3c_navigation_timing.js as issue resolved upstream

### DIFF
--- a/java/elemental2/dom/BUILD
+++ b/java/elemental2/dom/BUILD
@@ -62,13 +62,6 @@ patch_extern_file(
     patch_file = "w3c_event.js.diff",
 )
 
-# Patch for w3c_navigation_timing.js: Remove Performance.prototype.memory available only in blink.
-patch_extern_file(
-    name = "w3c_navigation_timing_patched",
-    src = "//third_party:w3c_navigation_timing.js",
-    patch_file = "w3c_navigation_timing.js.diff",
-)
-
 # Patch for w3c_serviceworker.js: Remove ServiceWorkerGlobalScope.prototype.indexedDB thatis not
 # part of the spec and introduce a cyclic dependency toelemental/indexeddb
 patch_extern_file(
@@ -112,7 +105,7 @@ filegroup(
         "//third_party:fetchapi.js",
         "//third_party:whatwg_console.js",
         ":w3c_serviceworker_patched",
-        ":w3c_navigation_timing_patched",
+        "//third_party:w3c_navigation_timing.js",
         "//third_party:w3c_clipboardevent.js",
         "//third_party:w3c_eventsource.js",
         "//third_party:w3c_elementtraversal.js",

--- a/java/elemental2/dom/w3c_navigation_timing.js.diff
+++ b/java/elemental2/dom/w3c_navigation_timing.js.diff
@@ -1,4 +1,0 @@
-212,214d211
-< // Nonstandard. Only available in Blink.
-< // Returns more granular results with the --enable-memory-info flag.
-< /** @type {MemoryInfo} */ Performance.prototype.memory;


### PR DESCRIPTION
This will need to be simultaneously applied with google/closure-compiler#3347