### PR TITLE
Feature: Chrome APIs

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -66,3 +66,9 @@ jsinterop_generator(
     name = "elemental2-indexeddb",
     exports = ["//java/elemental2/indexeddb"],
 )
+
+# Chrome api
+jsinterop_generator(
+    name = "elemental2-chrome",
+    exports = ["//java/elemental2/chrome"],
+)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Following are the different elemental2 modules and their target names:
  webgl      | `@com_google_elemental2//:elemental2-webgl-j2cl`
  media      | `@com_google_elemental2//:elemental2-media-j2cl`
  webstorage | `@com_google_elemental2//:elemental2-webstorage-j2cl`
+ chrome     | `@com_google_elemental2//:elemental2-chrome-j2cl`
 
 Maven dependencies
 ------------------
@@ -76,6 +77,7 @@ If your project use [Maven](https://maven.apache.org), add maven dependencies in
  webgl | `elemental2-webgl`
  media | `elemental2-media`
  webstorage | `elemental2-webstorage`
+ chrome | `elemental2-chrome`
 
 Download the jar files
 ----------------------
@@ -91,6 +93,7 @@ You can also download manually the jars files.
  webgl | [elemental2-webgl.jar](https://oss.sonatype.org/content/repositories/releases/com/google/elemental2/elemental2-webgl/1.0.0-RC1/elemental2-webgl-1.0.0-RC1.jar)
  media | [elemental2-media.jar](https://oss.sonatype.org/content/repositories/releases/com/google/elemental2/elemental2-media/1.0.0-RC1/elemental2-media-1.0.0-RC1.jar)
  webstorage | [elemental2-webstorage.jar](https://oss.sonatype.org/content/repositories/releases/com/google/elemental2/elemental2-webstorage/1.0.0-RC1/elemental2-webstorage-1.0.0-RC1.jar)
+ chrome | [elemental2-chrome.jar](https://oss.sonatype.org/content/repositories/releases/com/google/elemental2/elemental2-webstorage/1.0.0-RC1/elemental2-chrome-1.0.0-RC1.jar)
 
 GWT
 ---
@@ -106,6 +109,7 @@ If you use Elemental2 with [GWT](http://www.gwtproject.org/), you need to inheri
  webgl | `elemental2.webgl.WebGl`
  media | `elemental2.media.Media`
  webstorage | `elemental2.webstorage.WebStorage`
+ chrome | `elemental2.chrome.Chrome`
 
 Contributing
 ------------

--- a/java/elemental2/chrome/BUILD
+++ b/java/elemental2/chrome/BUILD
@@ -1,0 +1,39 @@
+# This package contains the build rule to build elemental2-chrome.
+
+package(default_visibility = [
+    "//:__subpackages__",
+])
+
+# Apache2
+licenses(["notice"])
+
+load(
+    "@com_google_jsinterop_generator//:jsinterop_generator.bzl",
+    "jsinterop_generator",
+)
+
+load(
+    "//build_defs/internal_do_not_use:elemental_utils.bzl",
+    "patch_extern_file",
+)
+
+patch_extern_file(
+    name = "chrome_patched",
+    src = "//third_party:chrome.js",
+    patch_file = "chrome.js.diff",
+)
+
+filegroup(
+    name = "externs",
+    srcs = [":chrome_patched"],
+)
+
+jsinterop_generator(
+    name = "chrome",
+    srcs = [":externs"],
+    integer_entities_files = ["integer_entities.txt"],
+    name_mapping_files = ["name_mappings.txt"],
+    deps = [
+        "//java/elemental2/core",
+        "//java/elemental2/dom",
+    ])

--- a/java/elemental2/chrome/chrome.js.diff
+++ b/java/elemental2/chrome/chrome.js.diff
@@ -1,0 +1,36 @@
+295c295
+<  * @extends {ChromeBaseEvent<function()>}
+---
+>  * @extends {ChromeBaseEvent<!Function>}
+303c303
+<  * @extends {ChromeBaseEvent<function(string)>}
+---
+>  * @extends {ChromeBaseEvent<!Function>}
+311c311
+<  * @extends {ChromeBaseEvent<function(boolean)>}
+---
+>  * @extends {ChromeBaseEvent<!Function>}
+319c319
+<  * @extends {ChromeBaseEvent<function(number)>}
+---
+>  * @extends {ChromeBaseEvent<!Function>}
+327c327
+<  * @extends {ChromeBaseEvent<function(!Object)>}
+---
+>  * @extends {ChromeBaseEvent<!Function>}
+335c335
+<  * @extends {ChromeBaseEvent<function(!Array<string>)>}
+---
+>  * @extends {ChromeBaseEvent<!Function>}
+343c343
+<  * @extends {ChromeBaseEvent<function(string, string)>}
+---
+>  * @extends {ChromeBaseEvent<!Function>}
+380,382c380,382
+<   USER: '',
+<   CAPTURE: '',
+<   EXTENSION: '',
+---
+>     USER: '',
+>     CAPTURE: '',
+>     EXTENSION: '',

--- a/java/elemental2/chrome/integer_entities.txt
+++ b/java/elemental2/chrome/integer_entities.txt
@@ -1,0 +1,7 @@
+elemental2.chrome.MessageSender.frameId
+elemental2.chrome.Tab.id
+elemental2.chrome.Tab.index
+elemental2.chrome.Tab.windowId
+elemental2.chrome.Tab.openerTabId
+elemental2.chrome.Tab.width
+elemental2.chrome.Tab.height

--- a/java/elemental2/chrome/name_mappings.txt
+++ b/java/elemental2/chrome/name_mappings.txt
@@ -1,0 +1,1 @@
+elemental2.chrome.chrome.Runtime.SendMessageCallbackFn.onInvoke.p0=response

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -258,3 +258,13 @@ alias(
     name = "jsinterop-base-j2cl",
     actual = "@com_google_jsinterop_base//:jsinterop-base-j2cl",
 )
+
+alias(
+    name = "chrome.js",
+    actual = "@com_google_closure_compiler//:contrib/externs/chrome.js",
+)
+
+alias(
+    name = "chrome_extensions.js",
+    actual = "@com_google_closure_compiler//:contrib/externs/chrome_extensions.js",
+)


### PR DESCRIPTION
This changeset introduces initial support for `chrome` APIs, as requested in google/elemental2#119. I'm filing it early to get feedback and make sure my approach is solid. I don't know if you guys have this on your roadmap or not. No worries if this PR is out of place temporally or the approach is entirely wrong.

Externs added from Closure Compiler:
- `contrib/externs/chrome.js`

Progress:
- [x] Patched extern file for `chrome.js`
- [x] Working build
- [ ] Investigate support for `chrome_extensions.js`