### PR TITLE
Add mediasource.js to elemental2.dom artifact

### DIFF
--- a/java/elemental2/dom/BUILD
+++ b/java/elemental2/dom/BUILD
@@ -72,6 +72,7 @@ filegroup(
         "//third_party:w3c_anim_timing.js",
         # TODO(dramaix): remove old webkit api and rename file to w3c_notifications.js
         "//third_party:webkit_notifications.js",
+        "//third_party:mediasource.js",
         "//third_party:streamsapi.js",
         "//third_party:url.js",
         "//third_party:w3c_abort.js",

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -225,6 +225,11 @@ alias(
 )
 
 alias(
+    name = "mediasource.js",
+    actual = "@com_google_closure_compiler//:externs/browser/mediasource.js",
+)
+
+alias(
     name = "mediakeys.js",
     actual = "@com_google_closure_compiler//:externs/browser/mediakeys.js",
 )


### PR DESCRIPTION
The Media Source Extensions are available in almost all desktop
browsers (97.28% worldwide coverage according to canisue) but does
not work in IE11 on a windows earlier than windows 8. Thus it seems
reasonable to add this to set of externs that generate the dom module.