### PR TITLE
Remove entry for nonstandard Audio API

### DIFF
--- a/java/elemental2/media/integer_entities.txt
+++ b/java/elemental2/media/integer_entities.txt
@@ -33,4 +33,3 @@ elemental2.media.OfflineAudioContext.null.length
 elemental2.media.OfflineAudioContext.null.numberOfChannels
 elemental2.media.MediaKeyStatusMap.getSize
 elemental2.media.ScriptProcessorNode.bufferSize
-elemental2.media.WebkitOfflineAudioContext.null.length


### PR DESCRIPTION
In google/closure-compiler#3407 the nonstandard APIs are moved to a
separate extern that is not included in elemental2 build.
