### PR TITLE
Use the same version of closure-compiler that rules_closure provides

### DIFF
--- a/build_defs/repository.bzl
+++ b/build_defs/repository.bzl
@@ -3,12 +3,12 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 _JSINTEROP_GENERATOR_VERSION = "master"
-_CLOSURE_COMPILER_VERSION = "master"
+_CLOSURE_COMPILER_VERSION = "20200112"
 
 def load_elemental2_repo_deps():
     http_archive(
         name = "com_google_closure_compiler",
-        url = "https://github.com/google/closure-compiler/archive/%s.zip" % _CLOSURE_COMPILER_VERSION,
+        url = "https://github.com/google/closure-compiler/archive/v%s.zip" % _CLOSURE_COMPILER_VERSION,
         build_file = Label("//build_defs/internal_do_not_use:jscomp.BUILD"),
         strip_prefix = "closure-compiler-%s" % _CLOSURE_COMPILER_VERSION,
     )

--- a/java/elemental2/dom/w3c_event.js.diff
+++ b/java/elemental2/dom/w3c_event.js.diff
@@ -1,8 +1,8 @@
 36c36
-<  * @param {EventListener|function(this:THIS, !Event):*} listener
+<  * @param {EventListener|function(!Event):*} listener
 ---
 >  * @param {EventListener} listener
-48c48
-<  * @param {EventListener|function(this:THIS, !Event):*} listener
+46c46
+<  * @param {EventListener|function(!Event):*} listener
 ---
 >  * @param {EventListener} listener

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -249,7 +249,7 @@ alias(
 # to an extern rule.
 alias(
     name = "webassembly.js",
-    actual = "@com_google_closure_compiler//:externs/browser/webassembly.js",
+    actual = "@com_google_closure_compiler//:contrib/externs/webassembly.js",
 )
 
 alias(


### PR DESCRIPTION
This patch backs out the currently broken commit d15d513, which assumed that a `extern()` rule would see changes made on master of closure-compiler. However, only the `alias()` rules currently point to master of that repo - the `extern()` rules all point to the externs.zip in the closure-compiler that rules_closure provides, tagged in git as v20200112 (see https://github.com/bazelbuild/rules_closure/blob/master/closure/repositories.bzl#L657). 

However, the tagged artifact is the "unshaded" jar, and while it contains externs.zip, that zip does not contain the `contrib/externs/` directory, so both svg and webassembly, which were still in that directory as of 2020-01-12, must be referenced from the git repo directly, This is why I left the http_archive for closure, but just changed it to point at the specified tag.

If you decide to merge this, it might make sense to do it in two pieces so that the "revert" commit can be re-reverted. When J2cl's "io_bazel_rules_closure" rule is updated, the tagged closure-compiler here will have to be updated too.