### PR TITLE
Update elemental2-webassembly to correctly depend on -dom

### DIFF
--- a/maven/pom-webassembly.xml
+++ b/maven/pom-webassembly.xml
@@ -60,5 +60,10 @@
       <artifactId>elemental2-promise</artifactId>
       <version>__VERSION__</version>
     </dependency>
+    <dependency>
+      <groupId>__GROUP_ID__</groupId>
+      <artifactId>elemental2-dom</artifactId>
+      <version>__VERSION__</version>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
This change makes the pom files correctly reflect the dependencies
declared in https://github.com/google/elemental2/blob/b620018/java/elemental2/webassembly/BUILD#L29