### PR TITLE
Bazel defs: Add version parameters to load_elemental2_repo_deps

### DIFF
--- a/build_defs/repository.bzl
+++ b/build_defs/repository.bzl
@@ -5,16 +5,19 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 _JSINTEROP_GENERATOR_VERSION = "master"
 _CLOSURE_COMPILER_VERSION = "master"
 
-def load_elemental2_repo_deps():
+def load_elemental2_repo_deps(
+    closure_compiler_version = _CLOSURE_COMPILER_VERSION,
+    jsinterop_generator_version = _JSINTEROP_GENERATOR_VERSION):
+
     http_archive(
         name = "com_google_closure_compiler",
-        url = "https://github.com/google/closure-compiler/archive/%s.zip" % _CLOSURE_COMPILER_VERSION,
+        url = "https://github.com/google/closure-compiler/archive/%s.zip" % closure_compiler_version,
         build_file = Label("//build_defs/internal_do_not_use:jscomp.BUILD"),
-        strip_prefix = "closure-compiler-%s" % _CLOSURE_COMPILER_VERSION,
+        strip_prefix = "closure-compiler-%s" % closure_compiler_version,
     )
 
     http_archive(
         name = "com_google_jsinterop_generator",
-        url = "https://github.com/google/jsinterop-generator/archive/%s.zip" % _JSINTEROP_GENERATOR_VERSION,
-        strip_prefix = "jsinterop-generator-%s" % _JSINTEROP_GENERATOR_VERSION,
+        url = "https://github.com/google/jsinterop-generator/archive/%s.zip" % jsinterop_generator_version,
+        strip_prefix = "jsinterop-generator-%s" % jsinterop_generator_version,
     )


### PR DESCRIPTION
Since [HEAD of jsinterop-generator](https://github.com/google/jsinterop-generator/commit/95b77245e9cfac5d46bae43e26eb15f416565c0a) broke our builds, I would like to add a way of specifying the versions of the dependencies.

The default behaviour of `load_elemental2_repo_deps` stays unchanged due to the provided default values.